### PR TITLE
CREATE機能のテストを実装しました。

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
 	testImplementation 'com.github.database-rider:rider-spring:1.32.3'
+	testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.12.4'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/raisetech/todo/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/raisetech/todo/integrationtest/UserRestApiIntegrationTest.java
@@ -107,7 +107,7 @@ public class UserRestApiIntegrationTest {
         String response = mockMvc
                 .perform(MockMvcRequestBuilders
                         .post("/todos")
-                        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
@@ -134,7 +134,7 @@ public class UserRestApiIntegrationTest {
         String response = mockMvc
                 .perform(MockMvcRequestBuilders
                         .post("/todos")
-                        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
                                 "    \"task\": \"Updateの実装\"," +
                                 "    \"limitDate\": \"2022-8-25\"" +

--- a/src/test/java/com/raisetech/todo/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/raisetech/todo/integrationtest/UserRestApiIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -108,7 +109,8 @@ public class UserRestApiIntegrationTest {
                 .perform(MockMvcRequestBuilders
                         .post("/todos")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{}"))
+                        .content("{}")
+                        .header(HttpHeaders.ACCEPT_LANGUAGE, "ja-JP"))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
@@ -117,8 +119,8 @@ public class UserRestApiIntegrationTest {
                 "    \"status\": \"400\"," +
                 "    \"timestamp\": \"\"," +
                 "    \"message\": {" +
-                "        \"task\": \"must not be blank\"," +
-                "        \"limitDate\": \"must not be null\"" +
+                "        \"task\": \"空白は許可されていません\"," +
+                "        \"limitDate\": \"null は許可されていません\"" +
                 "    }" +
                 "}";
 

--- a/src/test/java/com/raisetech/todo/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/raisetech/todo/integrationtest/UserRestApiIntegrationTest.java
@@ -3,18 +3,23 @@ package com.raisetech.todo.integrationtest;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -69,5 +74,83 @@ public class UserRestApiIntegrationTest {
                 "    \"task\": \"Readの実装\"," +
                 "    \"limitDate\": \"2022-08-10\"" +
                 "}", response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/to_do_list.yml")
+    @Transactional
+    void 新規作成できること() throws Exception{
+        String response = mockMvc
+                .perform(MockMvcRequestBuilders
+                        .post("/todos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{" +
+                                "    \"task\": \"Updateの実装\"," +
+                                "    \"limitDate\": \"2022-08-25\"" +
+                                "}"))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(header().string("Location", "/todos/4"))
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("{" +
+                "    \"id\": 4," +
+                "    \"done\": false," +
+                "    \"task\": \"Updateの実装\"," +
+                "    \"limitDate\": \"2022-08-25\"" +
+                "}", response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/to_do_list.yml")
+    @Transactional
+    void nullをPOSTした時にBadRequestが返ってくること() throws Exception{
+        String response = mockMvc
+                .perform(MockMvcRequestBuilders
+                        .post("/todos")
+                        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .content("{}"))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        String expected = "{" +
+                "    \"error\": \"Bad Request\"," +
+                "    \"status\": \"400\"," +
+                "    \"timestamp\": \"\"," +
+                "    \"message\": {" +
+                "        \"task\": \"must not be blank\"," +
+                "        \"limitDate\": \"must not be null\"" +
+                "    }" +
+                "}";
+
+        JSONAssert.assertEquals(expected, response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
+    }
+
+    @Test
+    @DataSet(value = "datasets/to_do_list.yml")
+    @Transactional
+    void limitDateに有効な型以外をPOSTした時にBadRequestが返ってくること() throws Exception{
+        String response = mockMvc
+                .perform(MockMvcRequestBuilders
+                        .post("/todos")
+                        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .content("{" +
+                                "    \"task\": \"Updateの実装\"," +
+                                "    \"limitDate\": \"2022-8-25\"" +
+                                "}"))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        String expected = "{" +
+                "    \"error\": \"Bad Request\"," +
+                "    \"status\": \"400\"," +
+                "    \"timestamp\": \"\"," +
+                "    \"message\": \"2022-8-25は有効ではありません。limitDateは'yyyy-MM-dd'形式で入力してください。\"" +
+                "}";
+
+        JSONAssert.assertEquals(expected, response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
     }
 }

--- a/src/test/java/com/raisetech/todo/repository/ToDoRepositoryTest.java
+++ b/src/test/java/com/raisetech/todo/repository/ToDoRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.raisetech.todo.repository;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -42,5 +43,13 @@ class ToDoRepositoryTest {
     void IDを指定して特定のタスク情報が取得できること() {
         Optional<ToDoRecord> actual = toDoRepository.findById(1);
         assertThat(actual).isEqualTo(Optional.of(new ToDoRecord(1, false, "Readの実装", LocalDate.of(2022, 8, 10))));
+    }
+
+    @Test
+    @DataSet(value = "datasets/to_do_list.yml")
+    @ExpectedDataSet(value = "datasets/expected_insert_to_do_list.yml", ignoreCols = "id")
+    void タスクを新規登録できること() {
+                assertThat(toDoRepository.findAllTask().size()).isEqualTo(3);
+                toDoRepository.insert(new ToDoRecord(4, false, "Updateの実装", LocalDate.of(2022, 8, 25)));
     }
 }

--- a/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
+++ b/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
@@ -26,6 +28,9 @@ class ToDoServiceTest {
 
     @Mock
     ToDoRepository toDoRepository;
+
+    @Mock
+    ToDoRecord toDoRecord;
 
     @Test
     void タスク全件を正常に返すこと() {
@@ -65,5 +70,20 @@ class ToDoServiceTest {
         assertThrows(ResourceNotFoundException.class, ()-> toDoService.findById(1) );
 
         verify(toDoRepository, times(1)).findById(anyInt());
+    }
+
+    @Test
+    void 新規タスクを追加できること() {
+        try (MockedStatic<ToDoRecord> toDoRecordMockedStatic = Mockito.mockStatic(ToDoRecord.class)) {
+            toDoRecordMockedStatic
+                    .when(() -> ToDoRecord.newInstance("Updateの実装", LocalDate.of(2022, 8, 25)))
+                    .thenReturn(new ToDoRecord(4, false, "Updateの実装", LocalDate.of(2022, 8, 25)));
+            doNothing().when(toDoRepository).insert(any());
+
+            ToDoEntity actual = toDoService.create("Updateの実装", LocalDate.of(2022, 8, 25));
+            assertThat(actual).isEqualTo(new ToDoEntity(4, false, "Updateの実装", LocalDate.of(2022, 8, 25)));
+
+            verify(toDoRepository, times(1)).insert(any());
+        }
     }
 }

--- a/src/test/resources/datasets/expected_insert_to_do_list.yml
+++ b/src/test/resources/datasets/expected_insert_to_do_list.yml
@@ -1,0 +1,17 @@
+to_do_list:
+  - id: 1
+    is_done: 0
+    task: "Readの実装"
+    limit_date: "2022-08-10"
+  - id: 2
+    is_done: 0
+    task: "Createの実装"
+    limit_date: "2022-08-20"
+  - id: 3
+    is_done: 0
+    task: "Deleteの実装"
+    limit_date: "2022-08-30"
+  - id: 4
+    is_done: 0
+    task: "Updateの実装"
+    limit_date: "2022-08-25"


### PR DESCRIPTION
## 概要（このPRの対応範囲）

* CREATE機能のテストを実装しました。

## やったこと

- テスト機能の実装
	- **ToDoRepositoryTest クラス** b8e7fb329fe0844cd2636983b1ab30780a64b8e4
		- [x] タスクを新規登録できること
	- **ToDoServiceTest クラス** 42fefa0d728e6deb5f0c38581dbee16b71c483ef
		- [x] タスクを新規登録できること
	- **UserRestApiIntegrationTest クラス** 3aee97380a010b3afb0e47a9e705b30eaad4fdea
		- [x] 新規作成できること
		- [x] nullをPOSTした時にBadRequestが返ってくること
		- [x] limitDateに有効な型以外をPOSTした時にBadRequestが返ってくること