### PR TITLE
UPDATE機能を、nullなら更新しない部分更新に変更

### DIFF
--- a/src/main/java/com/raisetech/todo/controller/ToDoController.java
+++ b/src/main/java/com/raisetech/todo/controller/ToDoController.java
@@ -11,8 +11,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,8 +36,8 @@ public class ToDoController {
 
     @PatchMapping("/todos/{id}")
     public ResponseEntity<ToDoResponse> edit(@PathVariable("id") int id, @Validated @RequestBody ToDoUpdateForm updateForm){
-        ToDoEntity toDoEntity = toDoService.update(id, updateForm.getTask(), updateForm.getLimitDate());
-        ToDoResponse toDoResponse = new ToDoResponse(toDoEntity.getId(), toDoEntity.isDone(), toDoEntity.getTask(), toDoEntity.getLimitDate());
+        ToDoEntity toDoEntity = toDoService.update(id, updateForm.isDone(), updateForm.getTask(), updateForm.getLimitDate());
+        ToDoResponse toDoResponse = new ToDoResponse(id, toDoEntity.isDone(), toDoEntity.getTask(), toDoEntity.getLimitDate());
         return ResponseEntity.ok(toDoResponse);
     }
 }

--- a/src/main/java/com/raisetech/todo/controller/ToDoController.java
+++ b/src/main/java/com/raisetech/todo/controller/ToDoController.java
@@ -30,14 +30,14 @@ public class ToDoController {
     @PostMapping("/todos")
     public ResponseEntity<ToDoResponse> create(@Validated @RequestBody ToDoForm toDoForm){
         ToDoEntity toDoEntity = toDoService.create(toDoForm.getTask(), toDoForm.getLimitDate());
-        ToDoResponse toDoResponse = new ToDoResponse(toDoEntity.getId(), toDoEntity.isDone(), toDoEntity.getTask(), toDoEntity.getLimitDate());
+        ToDoResponse toDoResponse = new ToDoResponse(toDoEntity.getId(), toDoEntity.getDone(), toDoEntity.getTask(), toDoEntity.getLimitDate());
         return ResponseEntity.created(URI.create("/todos/" + toDoEntity.getId())).body(toDoResponse);
     }
 
     @PatchMapping("/todos/{id}")
     public ResponseEntity<ToDoResponse> edit(@PathVariable("id") int id, @Validated @RequestBody ToDoUpdateForm updateForm){
-        ToDoEntity toDoEntity = toDoService.update(id, updateForm.isDone(), updateForm.getTask(), updateForm.getLimitDate());
-        ToDoResponse toDoResponse = new ToDoResponse(id, toDoEntity.isDone(), toDoEntity.getTask(), toDoEntity.getLimitDate());
+        ToDoEntity toDoEntity = toDoService.update(id, updateForm.getDone(), updateForm.getTask(), updateForm.getLimitDate());
+        ToDoResponse toDoResponse = new ToDoResponse(id, toDoEntity.getDone(), toDoEntity.getTask(), toDoEntity.getLimitDate());
         return ResponseEntity.ok(toDoResponse);
     }
 }

--- a/src/main/java/com/raisetech/todo/form/ToDoUpdateForm.java
+++ b/src/main/java/com/raisetech/todo/form/ToDoUpdateForm.java
@@ -1,24 +1,30 @@
 package com.raisetech.todo.form;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@AllArgsConstructor
 @Data
 public class ToDoUpdateForm {
 
-    @NotBlank
+    boolean done;
+
     @Size(min = 1, max = 256)
     private String task;
 
-    @NotBlank
     private String limitDate;
 
     public LocalDate getLimitDate() {
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        return LocalDate.parse(limitDate, dtf);
+        if(limitDate != null) {
+            DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            return LocalDate.parse(limitDate, dtf);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/raisetech/todo/form/ToDoUpdateForm.java
+++ b/src/main/java/com/raisetech/todo/form/ToDoUpdateForm.java
@@ -2,7 +2,7 @@ package com.raisetech.todo.form;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Value;
 
 import javax.validation.constraints.Size;
 import java.time.LocalDate;
@@ -10,10 +10,10 @@ import java.time.format.DateTimeFormatter;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @AllArgsConstructor
-@Data
+@Value
 public class ToDoUpdateForm {
 
-    boolean done;
+    Boolean done;
 
     @Size(min = 1, max = 256)
     private String task;

--- a/src/main/java/com/raisetech/todo/repository/ToDoRecord.java
+++ b/src/main/java/com/raisetech/todo/repository/ToDoRecord.java
@@ -15,8 +15,4 @@ public class ToDoRecord {
     public static ToDoRecord newInstance(String task, LocalDate limitDate) {
         return new ToDoRecord(null, false, task, limitDate);
     }
-
-    public static ToDoRecord valueOf(int id, String task, LocalDate limitDate) {
-        return new ToDoRecord(id, false , task, limitDate);
-    }
 }

--- a/src/main/java/com/raisetech/todo/repository/ToDoRepository.java
+++ b/src/main/java/com/raisetech/todo/repository/ToDoRepository.java
@@ -20,17 +20,15 @@ public interface ToDoRepository {
 
     @Update("UPDATE to_do_list " +
             "SET " +
-                "is_done = CASE " +
-                        "WHEN #{done} IS NOT NULL " +
-                        "THEN #{done} " +
-                        "ELSE is_done " +
-                    "END, " +
-                "task = CASE " +
+                "is_done = #{done}, " +
+                "task = " +
+                    "CASE " +
                         "WHEN #{task} IS NOT NULL " +
                         "THEN #{task} " +
                         "ELSE task " +
                     "END, " +
-                "limit_date = CASE " +
+                "limit_date = " +
+                    "CASE " +
                         "WHEN #{limitDate} IS NOT NULL " +
                         "THEN #{limitDate} " +
                         "ELSE limit_date " +

--- a/src/main/java/com/raisetech/todo/repository/ToDoRepository.java
+++ b/src/main/java/com/raisetech/todo/repository/ToDoRepository.java
@@ -1,6 +1,5 @@
 package com.raisetech.todo.repository;
 
-import com.raisetech.todo.service.ToDoEntity;
 import org.apache.ibatis.annotations.*;
 
 import java.util.List;
@@ -19,6 +18,23 @@ public interface ToDoRepository {
     @Insert("INSERT INTO to_do_list (is_done, task, limit_date) VALUES (#{done}, #{task}, #{limitDate})")
     void insert(ToDoRecord toDoRecord);
 
-    @Update("UPDATE to_do_list SET task = #{task}, limit_date = #{limitDate} WHERE id = #{id}")
+    @Update("UPDATE to_do_list " +
+            "SET " +
+                "is_done = CASE " +
+                        "WHEN #{done} IS NOT NULL " +
+                        "THEN #{done} " +
+                        "ELSE is_done " +
+                    "END, " +
+                "task = CASE " +
+                        "WHEN #{task} IS NOT NULL " +
+                        "THEN #{task} " +
+                        "ELSE task " +
+                    "END, " +
+                "limit_date = CASE " +
+                        "WHEN #{limitDate} IS NOT NULL " +
+                        "THEN #{limitDate} " +
+                        "ELSE limit_date " +
+                    "END " +
+            "WHERE id = #{id}")
     void update(ToDoRecord toDoRecord);
 }

--- a/src/main/java/com/raisetech/todo/service/ToDoEntity.java
+++ b/src/main/java/com/raisetech/todo/service/ToDoEntity.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 public class ToDoEntity {
 
     int id;
-    boolean done;
+    Boolean done;
     String task;
     LocalDate limitDate;
 

--- a/src/main/java/com/raisetech/todo/service/ToDoService.java
+++ b/src/main/java/com/raisetech/todo/service/ToDoService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -37,11 +36,13 @@ public class ToDoService {
         return new ToDoEntity(toDoRecord.getId(), toDoRecord.isDone(), toDoRecord.getTask(), toDoRecord.getLimitDate());
     }
 
-    public ToDoEntity update(int id, String task, LocalDate limitDate) {
+    public ToDoEntity update(int id, boolean done, String task, LocalDate limitDate) {
         toDoRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("タスク (id = " + id + ") は存在しません"));
-        var toDoRecord = ToDoRecord.valueOf(id, task, limitDate);
+        var toDoRecord = new ToDoRecord(id, done, task, limitDate);
         toDoRepository.update(toDoRecord);
-        return new ToDoEntity(toDoRecord.getId(), toDoRecord.isDone(), toDoRecord.getTask(), toDoRecord.getLimitDate());
+        return toDoRepository.findById(id)
+                .map(updatedRecord -> new ToDoEntity(id, updatedRecord.isDone(), updatedRecord.getTask(), updatedRecord.getLimitDate()))
+                .orElseThrow(() -> new ResourceNotFoundException("タスク (id = " + id + ") は存在しません"));
     }
 }

--- a/src/main/java/com/raisetech/todo/service/ToDoService.java
+++ b/src/main/java/com/raisetech/todo/service/ToDoService.java
@@ -38,12 +38,11 @@ public class ToDoService {
     }
 
     public ToDoEntity update(int id, Boolean done, String task, LocalDate limitDate) {
-        toDoRepository.findById(id)
+        ToDoRecord nowToDoRecord = toDoRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("タスク (id = " + id + ") は存在しません"));
 
         if (done == null) {
-            Optional<ToDoRecord> nowToDoRecord = toDoRepository.findById(id);
-            done = nowToDoRecord.get().isDone();
+            done = nowToDoRecord.isDone();
         }
 
         var toDoRecord = new ToDoRecord(id, done, task, limitDate);

--- a/src/main/java/com/raisetech/todo/service/ToDoService.java
+++ b/src/main/java/com/raisetech/todo/service/ToDoService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,9 +37,15 @@ public class ToDoService {
         return new ToDoEntity(toDoRecord.getId(), toDoRecord.isDone(), toDoRecord.getTask(), toDoRecord.getLimitDate());
     }
 
-    public ToDoEntity update(int id, boolean done, String task, LocalDate limitDate) {
+    public ToDoEntity update(int id, Boolean done, String task, LocalDate limitDate) {
         toDoRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("タスク (id = " + id + ") は存在しません"));
+
+        if (done == null) {
+            Optional<ToDoRecord> nowToDoRecord = toDoRepository.findById(id);
+            done = nowToDoRecord.get().isDone();
+        }
+
         var toDoRecord = new ToDoRecord(id, done, task, limitDate);
         toDoRepository.update(toDoRecord);
         return toDoRepository.findById(id)

--- a/src/test/java/com/raisetech/todo/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/raisetech/todo/integrationtest/UserRestApiIntegrationTest.java
@@ -47,19 +47,19 @@ public class UserRestApiIntegrationTest {
                 "    {" +
                 "        \"id\": 1," +
                 "        \"done\": false," +
-                "        \"task\": \"Readの実装\"," +
+                "        \"task\": \"テスト用タスク１\"," +
                 "        \"limitDate\": \"2022-08-10\"" +
                 "    }," +
                 "    {" +
                 "        \"id\": 2," +
                 "        \"done\": false," +
-                "        \"task\": \"Createの実装\"," +
+                "        \"task\": \"テスト用タスク２\"," +
                 "        \"limitDate\": \"2022-08-20\"" +
                 "    }," +
                 "    {" +
                 "        \"id\": 3," +
                 "        \"done\": false," +
-                "        \"task\": \"Deleteの実装\"," +
+                "        \"task\": \"テスト用タスク３\"," +
                 "        \"limitDate\": \"2022-08-30\"" +
                 "    }" +
                 "]", response, JSONCompareMode.STRICT);
@@ -76,7 +76,7 @@ public class UserRestApiIntegrationTest {
         JSONAssert.assertEquals("{" +
                 "    \"id\": 1," +
                 "    \"done\": false," +
-                "    \"task\": \"Readの実装\"," +
+                "    \"task\": \"テスト用タスク１\"," +
                 "    \"limitDate\": \"2022-08-10\"" +
                 "}", response, JSONCompareMode.STRICT);
     }
@@ -113,8 +113,8 @@ public class UserRestApiIntegrationTest {
                         .post("/todos")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
-                                "    \"task\": \"Updateの実装\"," +
-                                "    \"limitDate\": \"2022-08-25\"" +
+                                "    \"task\": \"テスト用タスク４\"," +
+                                "    \"limitDate\": \"2022-09-01\"" +
                                 "}"))
                 .andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(header().string("Location", "/todos/4"))
@@ -123,8 +123,8 @@ public class UserRestApiIntegrationTest {
         JSONAssert.assertEquals("{" +
                 "    \"id\": 4," +
                 "    \"done\": false," +
-                "    \"task\": \"Updateの実装\"," +
-                "    \"limitDate\": \"2022-08-25\"" +
+                "    \"task\": \"テスト用タスク４\"," +
+                "    \"limitDate\": \"2022-09-01\"" +
                 "}", response, JSONCompareMode.STRICT);
     }
 
@@ -170,8 +170,8 @@ public class UserRestApiIntegrationTest {
                             .post("/todos")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{" +
-                                    "    \"task\": \"Updateの実装\"," +
-                                    "    \"limitDate\": \"2022-8-25\"" +
+                                    "    \"task\": \"テスト用タスク４\"," +
+                                    "    \"limitDate\": \"2022-9-1\"" +
                                     "}"))
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
@@ -180,7 +180,7 @@ public class UserRestApiIntegrationTest {
                     "    \"error\": \"Bad Request\"," +
                     "    \"status\": \"400\"," +
                     "    \"timestamp\": \"2022-08-24T00:00+09:00[Asia/Tokyo]\"," +
-                    "    \"message\": \"2022-8-25は有効ではありません。limitDateは'yyyy-MM-dd'形式で入力してください。\"" +
+                    "    \"message\": \"2022-9-1は有効ではありません。limitDateは'yyyy-MM-dd'形式で入力してください。\"" +
                     "}";
 
             JSONAssert.assertEquals(expected, response, JSONCompareMode.STRICT);
@@ -197,8 +197,8 @@ public class UserRestApiIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
                                 "    \"done\": true," +
-                                "    \"task\": \"Updateの実装\"," +
-                                "    \"limitDate\": \"2022-08-25\"" +
+                                "    \"task\": \"テスト用タスク３変更\"," +
+                                "    \"limitDate\": \"2022-09-30\"" +
                                 "}"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
@@ -206,8 +206,8 @@ public class UserRestApiIntegrationTest {
         JSONAssert.assertEquals("{" +
                 "    \"id\": 3," +
                 "    \"done\": true," +
-                "    \"task\": \"Updateの実装\"," +
-                "    \"limitDate\": \"2022-08-25\"" +
+                "    \"task\": \"テスト用タスク３変更\"," +
+                "    \"limitDate\": \"2022-09-30\"" +
                 "}", response, JSONCompareMode.STRICT);
     }
 
@@ -228,7 +228,7 @@ public class UserRestApiIntegrationTest {
         JSONAssert.assertEquals("{" +
                 "    \"id\": 3," +
                 "    \"done\": true," +
-                "    \"task\": \"Deleteの実装\"," +
+                "    \"task\": \"テスト用タスク３\"," +
                 "    \"limitDate\": \"2022-08-30\"" +
                 "}", response, JSONCompareMode.STRICT);
     }
@@ -248,7 +248,7 @@ public class UserRestApiIntegrationTest {
         JSONAssert.assertEquals("{" +
                 "    \"id\": 3," +
                 "    \"done\": false," +
-                "    \"task\": \"Deleteの実装\"," +
+                "    \"task\": \"テスト用タスク３\"," +
                 "    \"limitDate\": \"2022-08-30\"" +
                 "}", response, JSONCompareMode.STRICT);
     }
@@ -256,7 +256,7 @@ public class UserRestApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/to_do_list.yml")
     @Transactional
-    void limitDateに有効な型以外に変更しようとした時にBadRequestが返ってくること() throws Exception{
+    void limitDateを有効な型以外に変更しようとした時にBadRequestが返ってくること() throws Exception{
         try(MockedStatic<ZonedDateTime> zonedDateTimeMockedStatic = Mockito.mockStatic(ZonedDateTime.class)) {
             zonedDateTimeMockedStatic.when(ZonedDateTime::now).thenReturn(zonedDateTime);
 
@@ -265,7 +265,7 @@ public class UserRestApiIntegrationTest {
                             .patch("/todos/3")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{" +
-                                    "    \"task\": \"Updateの実装\"," +
+                                    "    \"task\": \"テスト用タスク変更\"," +
                                     "    \"limitDate\": \"aaaa\"" +
                                     "}"))
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
@@ -293,8 +293,8 @@ public class UserRestApiIntegrationTest {
                             .patch("/todos/99")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{" +
-                                    "    \"task\": \"Updateの実装\"," +
-                                    "    \"limitDate\": \"2022-08-25\"" +
+                                    "    \"task\": \"テスト用タスク３変更\"," +
+                                    "    \"limitDate\": \"2022-09-30\"" +
                                     "}"))
                     .andExpect(MockMvcResultMatchers.status().isNotFound())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);

--- a/src/test/java/com/raisetech/todo/repository/ToDoRepositoryTest.java
+++ b/src/test/java/com/raisetech/todo/repository/ToDoRepositoryTest.java
@@ -60,4 +60,12 @@ class ToDoRepositoryTest {
         assertThat(toDoRepository.findAllTask().size()).isEqualTo(3);
         toDoRepository.update(new ToDoRecord(3, false, "Updateの実装", LocalDate.of(2022, 8, 25)));
     }
+
+    @Test
+    @DataSet(value = "datasets/to_do_list.yml")
+    @ExpectedDataSet(value = "datasets/to_do_list.yml", ignoreCols = "id")
+    void nullが入力された時にタスクを更新しないこと() {
+        assertThat(toDoRepository.findAllTask().size()).isEqualTo(3);
+        toDoRepository.update(new ToDoRecord(3, false, null, null));
+    }
 }

--- a/src/test/java/com/raisetech/todo/repository/ToDoRepositoryTest.java
+++ b/src/test/java/com/raisetech/todo/repository/ToDoRepositoryTest.java
@@ -31,9 +31,9 @@ class ToDoRepositoryTest {
         assertThat(actual)
                 .hasSize(3)
                 .contains(
-                        new ToDoRecord(1, false, "Readの実装", LocalDate.of(2022, 8, 10)),
-                        new ToDoRecord(2, false, "Createの実装", LocalDate.of(2022, 8, 20)),
-                        new ToDoRecord(3, false, "Deleteの実装", LocalDate.of(2022, 8, 30))
+                        new ToDoRecord(1, false, "テスト用タスク１", LocalDate.of(2022, 8, 10)),
+                        new ToDoRecord(2, false, "テスト用タスク２", LocalDate.of(2022, 8, 20)),
+                        new ToDoRecord(3, false, "テスト用タスク３", LocalDate.of(2022, 8, 30))
                 );
     }
 
@@ -42,7 +42,7 @@ class ToDoRepositoryTest {
     @Transactional
     void IDを指定して特定のタスク情報が取得できること() {
         Optional<ToDoRecord> actual = toDoRepository.findById(1);
-        assertThat(actual).isEqualTo(Optional.of(new ToDoRecord(1, false, "Readの実装", LocalDate.of(2022, 8, 10))));
+        assertThat(actual).isEqualTo(Optional.of(new ToDoRecord(1, false, "テスト用タスク１", LocalDate.of(2022, 8, 10))));
     }
 
     @Test
@@ -50,7 +50,7 @@ class ToDoRepositoryTest {
     @ExpectedDataSet(value = "datasets/expected_insert_to_do_list.yml", ignoreCols = "id")
     void タスクを新規登録できること() {
                 assertThat(toDoRepository.findAllTask().size()).isEqualTo(3);
-                toDoRepository.insert(new ToDoRecord(4, false, "Updateの実装", LocalDate.of(2022, 8, 25)));
+                toDoRepository.insert(new ToDoRecord(4, false, "テスト用タスク４", LocalDate.of(2022, 9, 1)));
     }
 
     @Test
@@ -58,7 +58,7 @@ class ToDoRepositoryTest {
     @ExpectedDataSet(value = "datasets/expected_update_to_do_list.yml", ignoreCols = "id")
     void タスクを変更できること() {
         assertThat(toDoRepository.findAllTask().size()).isEqualTo(3);
-        toDoRepository.update(new ToDoRecord(3, false, "Updateの実装", LocalDate.of(2022, 8, 25)));
+        toDoRepository.update(new ToDoRecord(3, true, "テスト用タスク３変更", LocalDate.of(2022, 9, 30)));
     }
 
     @Test

--- a/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
+++ b/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
@@ -100,7 +100,7 @@ class ToDoServiceTest {
     }
 
     @Test
-    void nullがあっても部分的にタスクを変更できること() {
+    void done以外がnullの時にdoneだけ部分的に変更できること() {
         ToDoRecord toDoRecordMock = new ToDoRecord(3, true, "Updateの実装", LocalDate.of(2022,8,30));
 
         doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
@@ -110,6 +110,48 @@ class ToDoServiceTest {
         assertThat(actual).isEqualTo(new ToDoEntity(3, true, "Updateの実装", LocalDate.of(2022, 8, 30)));
 
         verify(toDoRepository, times(2)).findById(anyInt());
+        verify(toDoRepository, times(1)).update(any());
+    }
+
+    @Test
+    void task以外がnullの時にtaskだけ部分的に変更できること() {
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "Updateの実装", LocalDate.of(2022,8,30));
+
+        doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
+        doNothing().when(toDoRepository).update(any());
+
+        ToDoEntity actual = toDoService.update(3, null, "Updateの実装", null);
+        assertThat(actual).isEqualTo(new ToDoEntity(3, false, "Updateの実装", LocalDate.of(2022, 8, 30)));
+
+        verify(toDoRepository, times(3)).findById(anyInt());
+        verify(toDoRepository, times(1)).update(any());
+    }
+
+    @Test
+    void limitDate以外がnullの時にlimitdateだけ部分的に変更できること() {
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "Updateの実装", LocalDate.of(2022,8,30));
+
+        doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
+        doNothing().when(toDoRepository).update(any());
+
+        ToDoEntity actual = toDoService.update(3, null, null, LocalDate.of(2022,8,30));
+        assertThat(actual).isEqualTo(new ToDoEntity(3, false, "Updateの実装", LocalDate.of(2022, 8, 30)));
+
+        verify(toDoRepository, times(3)).findById(anyInt());
+        verify(toDoRepository, times(1)).update(any());
+    }
+
+    @Test
+    void 部分更新で全ての値がnullの時に何も変更しないこと() {
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "Updateの実装", LocalDate.of(2022,8,30));
+
+        doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
+        doNothing().when(toDoRepository).update(any());
+
+        ToDoEntity actual = toDoService.update(3, null, null, null);
+        assertThat(actual).isEqualTo(new ToDoEntity(3, false, "Updateの実装", LocalDate.of(2022, 8, 30)));
+
+        verify(toDoRepository, times(3)).findById(anyInt());
         verify(toDoRepository, times(1)).update(any());
     }
 

--- a/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
+++ b/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
@@ -32,15 +32,15 @@ class ToDoServiceTest {
     @Test
     void タスク全件を正常に返すこと() {
         List<ToDoEntity>  allTasksEntity = Arrays.asList(
-                new ToDoEntity(1, false, "Readの実装", LocalDate.of(2022, 8, 10)),
-                new ToDoEntity(2, false, "Createの実装", LocalDate.of(2022, 8, 20)),
-                new ToDoEntity(3, false, "Deleteの実装", LocalDate.of(2022, 8, 30))
+                new ToDoEntity(1, false, "テスト用タスク１", LocalDate.of(2022, 8, 10)),
+                new ToDoEntity(2, false, "テスト用タスク２", LocalDate.of(2022, 8, 20)),
+                new ToDoEntity(3, false, "テスト用タスク３", LocalDate.of(2022, 8, 30))
         ) ;
 
         List<ToDoRecord>  allTasksRecord = Arrays.asList(
-                new ToDoRecord(1, false, "Readの実装", LocalDate.of(2022, 8, 10)),
-                new ToDoRecord(2, false, "Createの実装", LocalDate.of(2022, 8, 20)),
-                new ToDoRecord(3, false, "Deleteの実装", LocalDate.of(2022, 8, 30))
+                new ToDoRecord(1, false, "テスト用タスク１", LocalDate.of(2022, 8, 10)),
+                new ToDoRecord(2, false, "テスト用タスク２", LocalDate.of(2022, 8, 20)),
+                new ToDoRecord(3, false, "テスト用タスク３", LocalDate.of(2022, 8, 30))
         ) ;
         doReturn(allTasksRecord).when(toDoRepository).findAllTask();
 
@@ -52,11 +52,11 @@ class ToDoServiceTest {
 
     @Test
     void 存在するタスクのIDを指定したときに正常にタスクが返されること() {
-        doReturn(Optional.of(new ToDoRecord(1, false, "Readの実装", LocalDate.of(2022,8,10))))
+        doReturn(Optional.of(new ToDoRecord(1, false, "テスト用タスク１", LocalDate.of(2022,8,10))))
                 .when(toDoRepository).findById(1);
 
         ToDoEntity actual = toDoService.findById(1);
-        assertThat(actual).isEqualTo(new ToDoEntity(1, false, "Readの実装", LocalDate.of(2022,8,10)));
+        assertThat(actual).isEqualTo(new ToDoEntity(1, false, "テスト用タスク１", LocalDate.of(2022,8,10)));
 
         verify(toDoRepository, times(1)).findById(1);
     }
@@ -74,12 +74,12 @@ class ToDoServiceTest {
     void 新規タスクを追加できること() {
         try (MockedStatic<ToDoRecord> toDoRecordMockedStatic = Mockito.mockStatic(ToDoRecord.class)) {
             toDoRecordMockedStatic
-                    .when(() -> ToDoRecord.newInstance("Updateの実装", LocalDate.of(2022, 8, 25)))
-                    .thenReturn(new ToDoRecord(4, false, "Updateの実装", LocalDate.of(2022, 8, 25)));
+                    .when(() -> ToDoRecord.newInstance("テスト用タスク４", LocalDate.of(2022, 9, 1)))
+                    .thenReturn(new ToDoRecord(4, false, "テスト用タスク４", LocalDate.of(2022, 9, 1)));
             doNothing().when(toDoRepository).insert(any());
 
-            ToDoEntity actual = toDoService.create("Updateの実装", LocalDate.of(2022, 8, 25));
-            assertThat(actual).isEqualTo(new ToDoEntity(4, false, "Updateの実装", LocalDate.of(2022, 8, 25)));
+            ToDoEntity actual = toDoService.create("テスト用タスク４", LocalDate.of(2022, 9, 1));
+            assertThat(actual).isEqualTo(new ToDoEntity(4, false, "テスト用タスク４", LocalDate.of(2022, 9, 1)));
 
             verify(toDoRepository, times(1)).insert(any());
         }
@@ -87,13 +87,13 @@ class ToDoServiceTest {
 
     @Test
     void タスクを変更できること() {
-        ToDoRecord toDoRecordMock = new ToDoRecord(3, true, "Updateの実装", LocalDate.of(2022,8,25));
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, true, "テスト用タスク３変更", LocalDate.of(2022,9,30));
 
         doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
         doNothing().when(toDoRepository).update(any());
 
-        ToDoEntity actual = toDoService.update(3, true, "Updateの実装", LocalDate.of(2022, 8, 25));
-        assertThat(actual).isEqualTo(new ToDoEntity(3, true, "Updateの実装", LocalDate.of(2022, 8, 25)));
+        ToDoEntity actual = toDoService.update(3, true, "テスト用タスク３変更", LocalDate.of(2022, 9, 30));
+        assertThat(actual).isEqualTo(new ToDoEntity(3, true, "テスト用タスク３変更", LocalDate.of(2022, 9, 30)));
 
         verify(toDoRepository, times(2)).findById(anyInt());
         verify(toDoRepository, times(1)).update(any());
@@ -101,13 +101,13 @@ class ToDoServiceTest {
 
     @Test
     void done以外がnullの時にdoneだけ部分的に変更できること() {
-        ToDoRecord toDoRecordMock = new ToDoRecord(3, true, "Updateの実装", LocalDate.of(2022,8,30));
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, true, "テスト用タスク３", LocalDate.of(2022,9,1));
 
         doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
         doNothing().when(toDoRepository).update(any());
 
         ToDoEntity actual = toDoService.update(3, true, null, null);
-        assertThat(actual).isEqualTo(new ToDoEntity(3, true, "Updateの実装", LocalDate.of(2022, 8, 30)));
+        assertThat(actual).isEqualTo(new ToDoEntity(3, true, "テスト用タスク３", LocalDate.of(2022, 9, 1)));
 
         verify(toDoRepository, times(2)).findById(anyInt());
         verify(toDoRepository, times(1)).update(any());
@@ -115,13 +115,13 @@ class ToDoServiceTest {
 
     @Test
     void task以外がnullの時にtaskだけ部分的に変更できること() {
-        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "Updateの実装", LocalDate.of(2022,8,30));
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "テスト用タスク３変更", LocalDate.of(2022,8,30));
 
         doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
         doNothing().when(toDoRepository).update(any());
 
-        ToDoEntity actual = toDoService.update(3, null, "Updateの実装", null);
-        assertThat(actual).isEqualTo(new ToDoEntity(3, false, "Updateの実装", LocalDate.of(2022, 8, 30)));
+        ToDoEntity actual = toDoService.update(3, null, "テスト用タスク３変更", null);
+        assertThat(actual).isEqualTo(new ToDoEntity(3, false, "テスト用タスク３変更", LocalDate.of(2022, 8, 30)));
 
         verify(toDoRepository, times(3)).findById(anyInt());
         verify(toDoRepository, times(1)).update(any());
@@ -129,13 +129,13 @@ class ToDoServiceTest {
 
     @Test
     void limitDate以外がnullの時にlimitdateだけ部分的に変更できること() {
-        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "Updateの実装", LocalDate.of(2022,8,30));
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "テスト用タスク３", LocalDate.of(2022,9, 30));
 
         doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
         doNothing().when(toDoRepository).update(any());
 
-        ToDoEntity actual = toDoService.update(3, null, null, LocalDate.of(2022,8,30));
-        assertThat(actual).isEqualTo(new ToDoEntity(3, false, "Updateの実装", LocalDate.of(2022, 8, 30)));
+        ToDoEntity actual = toDoService.update(3, null, null, LocalDate.of(2022,9, 30));
+        assertThat(actual).isEqualTo(new ToDoEntity(3, false, "テスト用タスク３", LocalDate.of(2022, 9, 30)));
 
         verify(toDoRepository, times(3)).findById(anyInt());
         verify(toDoRepository, times(1)).update(any());
@@ -143,13 +143,13 @@ class ToDoServiceTest {
 
     @Test
     void 部分更新で全ての値がnullの時に何も変更しないこと() {
-        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "Updateの実装", LocalDate.of(2022,8,30));
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "テスト用タスク３", LocalDate.of(2022,8,30));
 
         doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
         doNothing().when(toDoRepository).update(any());
 
         ToDoEntity actual = toDoService.update(3, null, null, null);
-        assertThat(actual).isEqualTo(new ToDoEntity(3, false, "Updateの実装", LocalDate.of(2022, 8, 30)));
+        assertThat(actual).isEqualTo(new ToDoEntity(3, false, "テスト用タスク３", LocalDate.of(2022, 8, 30)));
 
         verify(toDoRepository, times(3)).findById(anyInt());
         verify(toDoRepository, times(1)).update(any());
@@ -158,8 +158,8 @@ class ToDoServiceTest {
     @Test
     void 存在しないタスクを変更しようとしたときに正常に例外が投げられていること() {
         doReturn(Optional.empty()).when(toDoRepository).findById(anyInt());
-        ResourceNotFoundException e = assertThrows(ResourceNotFoundException.class, ()-> toDoService.update(4, true, "Updateの実装", LocalDate.of(2022, 8, 30)) );
-        assertThat(e.getMessage()).isEqualTo("タスク (id = 4) は存在しません");
+        ResourceNotFoundException e = assertThrows(ResourceNotFoundException.class, ()-> toDoService.update(99, true, "テスト用タスク９９", LocalDate.of(2022, 12, 1)) );
+        assertThat(e.getMessage()).isEqualTo("タスク (id = 99) は存在しません");
 
         verify(toDoRepository, times(1)).findById(anyInt());
     }

--- a/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
+++ b/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
@@ -123,7 +123,7 @@ class ToDoServiceTest {
         ToDoEntity actual = toDoService.update(3, null, "テスト用タスク３変更", null);
         assertThat(actual).isEqualTo(new ToDoEntity(3, false, "テスト用タスク３変更", LocalDate.of(2022, 8, 30)));
 
-        verify(toDoRepository, times(3)).findById(anyInt());
+        verify(toDoRepository, times(2)).findById(anyInt());
         verify(toDoRepository, times(1)).update(any());
     }
 
@@ -137,7 +137,7 @@ class ToDoServiceTest {
         ToDoEntity actual = toDoService.update(3, null, null, LocalDate.of(2022,9, 30));
         assertThat(actual).isEqualTo(new ToDoEntity(3, false, "テスト用タスク３", LocalDate.of(2022, 9, 30)));
 
-        verify(toDoRepository, times(3)).findById(anyInt());
+        verify(toDoRepository, times(2)).findById(anyInt());
         verify(toDoRepository, times(1)).update(any());
     }
 
@@ -151,7 +151,7 @@ class ToDoServiceTest {
         ToDoEntity actual = toDoService.update(3, null, null, null);
         assertThat(actual).isEqualTo(new ToDoEntity(3, false, "テスト用タスク３", LocalDate.of(2022, 8, 30)));
 
-        verify(toDoRepository, times(3)).findById(anyInt());
+        verify(toDoRepository, times(2)).findById(anyInt());
         verify(toDoRepository, times(1)).update(any());
     }
 

--- a/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
+++ b/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
@@ -87,26 +87,36 @@ class ToDoServiceTest {
 
     @Test
     void タスクを変更できること() {
-        ToDoRecord toDoRecordMock = new ToDoRecord(3, false, "Updateの実装", LocalDate.of(2022,8,25));
-        try (MockedStatic<ToDoRecord> toDoRecordMockedStatic = Mockito.mockStatic(ToDoRecord.class)) {
-            toDoRecordMockedStatic
-                    .when(() -> ToDoRecord.valueOf(3, "Updateの実装", LocalDate.of(2022, 8, 25)))
-                    .thenReturn(toDoRecordMock);
-            doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
-            doNothing().when(toDoRepository).update(any());
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, true, "Updateの実装", LocalDate.of(2022,8,25));
 
-            ToDoEntity actual = toDoService.update(3, "Updateの実装", LocalDate.of(2022, 8, 25));
-            assertThat(actual).isEqualTo(new ToDoEntity(3, false, "Updateの実装", LocalDate.of(2022, 8, 25)));
+        doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
+        doNothing().when(toDoRepository).update(any());
 
-            verify(toDoRepository, times(1)).findById(anyInt());
-            verify(toDoRepository, times(1)).update(any());
-        }
+        ToDoEntity actual = toDoService.update(3, true, "Updateの実装", LocalDate.of(2022, 8, 25));
+        assertThat(actual).isEqualTo(new ToDoEntity(3, true, "Updateの実装", LocalDate.of(2022, 8, 25)));
+
+        verify(toDoRepository, times(2)).findById(anyInt());
+        verify(toDoRepository, times(1)).update(any());
+    }
+
+    @Test
+    void nullがあっても部分的にタスクを変更できること() {
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, true, "Updateの実装", LocalDate.of(2022,8,30));
+
+        doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
+        doNothing().when(toDoRepository).update(any());
+
+        ToDoEntity actual = toDoService.update(3, true, null, null);
+        assertThat(actual).isEqualTo(new ToDoEntity(3, true, "Updateの実装", LocalDate.of(2022, 8, 30)));
+
+        verify(toDoRepository, times(2)).findById(anyInt());
+        verify(toDoRepository, times(1)).update(any());
     }
 
     @Test
     void 存在しないタスクを変更しようとしたときに正常に例外が投げられていること() {
         doReturn(Optional.empty()).when(toDoRepository).findById(anyInt());
-        ResourceNotFoundException e = assertThrows(ResourceNotFoundException.class, ()-> toDoService.update(4, "Updateの実装", LocalDate.of(2022, 8, 30)) );
+        ResourceNotFoundException e = assertThrows(ResourceNotFoundException.class, ()-> toDoService.update(4, true, "Updateの実装", LocalDate.of(2022, 8, 30)) );
         assertThat(e.getMessage()).isEqualTo("タスク (id = 4) は存在しません");
 
         verify(toDoRepository, times(1)).findById(anyInt());

--- a/src/test/resources/datasets/expected_insert_to_do_list.yml
+++ b/src/test/resources/datasets/expected_insert_to_do_list.yml
@@ -1,17 +1,17 @@
 to_do_list:
   - id: 1
     is_done: 0
-    task: "Readの実装"
+    task: "テスト用タスク１"
     limit_date: "2022-08-10"
   - id: 2
     is_done: 0
-    task: "Createの実装"
+    task: "テスト用タスク２"
     limit_date: "2022-08-20"
   - id: 3
     is_done: 0
-    task: "Deleteの実装"
+    task: "テスト用タスク３"
     limit_date: "2022-08-30"
   - id: 4
     is_done: 0
-    task: "Updateの実装"
-    limit_date: "2022-08-25"
+    task: "テスト用タスク４"
+    limit_date: "2022-09-01"

--- a/src/test/resources/datasets/expected_update_to_do_list.yml
+++ b/src/test/resources/datasets/expected_update_to_do_list.yml
@@ -1,13 +1,13 @@
 to_do_list:
   - id: 1
     is_done: 0
-    task: "Readの実装"
+    task: "テスト用タスク１"
     limit_date: "2022-08-10"
   - id: 2
     is_done: 0
-    task: "Createの実装"
+    task: "テスト用タスク２"
     limit_date: "2022-08-20"
   - id: 3
-    is_done: 0
-    task: "Updateの実装"
-    limit_date: "2022-08-25"
+    is_done: 1
+    task: "テスト用タスク３変更"
+    limit_date: "2022-09-30"

--- a/src/test/resources/datasets/to_do_list.yml
+++ b/src/test/resources/datasets/to_do_list.yml
@@ -1,13 +1,13 @@
 to_do_list:
   - id: 1
     is_done: 0
-    task: "Readの実装"
+    task: "テスト用タスク１"
     limit_date: "2022-08-10"
   - id: 2
     is_done: 0
-    task: "Createの実装"
+    task: "テスト用タスク２"
     limit_date: "2022-08-20"
   - id: 3
     is_done: 0
-    task: "Deleteの実装"
+    task: "テスト用タスク３"
     limit_date: "2022-08-30"


### PR DESCRIPTION
## 概要（このPRの対応範囲）

* 新規CRUDアプリ（ToDoList）のUPDATE部分を変更しました。
  nullの場合は更新しない部分更新になりました。
  done、task、limitDateの更新したい項目だけPATCHしたら、その部分だけ変更されます。  
* 部分更新に変更したことに伴い、テストも修正しました。


## やったこと

- UPDATE機能の実装 767dfab50637922c08bd542a42f044dc35926f7e
	- [x] タスク部分編集機能（PATCH:/todos/{id})
- 例外処理
	- [x] 「nullをPATCHリクエストした時に、400Bad Requestのエラーメッセージを返す」削除
- テスト機能
	- **ToDoRepositoryTest クラス** c94c499117ee78c19e2acbb5d3bcf56e749d2baa
		- [x] 「nullが入力された時にタスクを更新しないこと」新規追加
	- **ToDoServiceTest クラス** 9242287e42db61084b641de1118053a35f274e15
		- [x] 「タスクを変更できること」修正
		- [x] 「nullがあっても部分的にタスクを変更できること」
		- [x] 「存在しないタスクを変更しようとしたときに正常に例外が投げられていること」修正
	- **UserRestApiIntegrationTest クラス** 65cfbce0d53a5d03403c37c2529b4a4f8eed7606
		- [x] 「タスクを変更できること」修正
		- [x] 「nullにタスク変更しようとした時にBadRequestが返ってくること」削除
		- [x] 「入力した項目だけ部分更新されてnullなら更新されないこと」新規追加
		- [x] 「全ての項目をnullでPATCHした時に何も更新されていないこと」新規追加