### PR TITLE
DELETE機能を実装しました。

### DIFF
--- a/src/main/java/com/raisetech/todo/controller/ToDoController.java
+++ b/src/main/java/com/raisetech/todo/controller/ToDoController.java
@@ -40,4 +40,10 @@ public class ToDoController {
         ToDoResponse toDoResponse = new ToDoResponse(id, toDoEntity.getDone(), toDoEntity.getTask(), toDoEntity.getLimitDate());
         return ResponseEntity.ok(toDoResponse);
     }
+
+    @DeleteMapping("/todos/{id}")
+    public ResponseEntity delete(@PathVariable("id") int id){
+        toDoService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/raisetech/todo/repository/ToDoRepository.java
+++ b/src/main/java/com/raisetech/todo/repository/ToDoRepository.java
@@ -35,4 +35,7 @@ public interface ToDoRepository {
                     "END " +
             "WHERE id = #{id}")
     void update(ToDoRecord toDoRecord);
+
+    @Delete("DELETE FROM to_do_list WHERE id = #{id}")
+    void deleteById(int id);
 }

--- a/src/main/java/com/raisetech/todo/service/ToDoService.java
+++ b/src/main/java/com/raisetech/todo/service/ToDoService.java
@@ -51,4 +51,10 @@ public class ToDoService {
                 .map(updatedRecord -> new ToDoEntity(id, updatedRecord.isDone(), updatedRecord.getTask(), updatedRecord.getLimitDate()))
                 .orElseThrow(() -> new ResourceNotFoundException("タスク (id = " + id + ") は存在しません"));
     }
+
+    public void deleteById(int id) {
+        toDoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("タスク (id = " + id + ") は存在しません"));
+        toDoRepository.deleteById(id);
+    }
 }

--- a/src/test/java/com/raisetech/todo/repository/ToDoRepositoryTest.java
+++ b/src/test/java/com/raisetech/todo/repository/ToDoRepositoryTest.java
@@ -68,4 +68,13 @@ class ToDoRepositoryTest {
         assertThat(toDoRepository.findAllTask().size()).isEqualTo(3);
         toDoRepository.update(new ToDoRecord(3, false, null, null));
     }
+
+    @Test
+    @DataSet(value = "datasets/to_do_list.yml")
+    @ExpectedDataSet(value = "datasets/expected_delete_to_do_list.yml", ignoreCols = "id")
+    void タスクを削除できること() {
+        assertThat(toDoRepository.findAllTask().size()).isEqualTo(3);
+        toDoRepository.deleteById(3);
+        assertThat(toDoRepository.findAllTask().size()).isEqualTo(2);
+    }
 }

--- a/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
+++ b/src/test/java/com/raisetech/todo/service/ToDoServiceTest.java
@@ -163,4 +163,25 @@ class ToDoServiceTest {
 
         verify(toDoRepository, times(1)).findById(anyInt());
     }
+
+    @Test
+    void タスクを削除できること() {
+        ToDoRecord toDoRecordMock = new ToDoRecord(3, true, "テスト用タスク３", LocalDate.of(2022,8,30));
+        doReturn(Optional.of(toDoRecordMock)).when(toDoRepository).findById(3);
+        doNothing().when(toDoRepository).deleteById(anyInt());
+
+        toDoService.deleteById(3);
+
+        verify(toDoRepository, times(1)).findById(anyInt());
+        verify(toDoRepository, times(1)).deleteById(anyInt());
+    }
+
+    @Test
+    void 存在しないタスクを削除しようとしたときに正常に例外が投げられていること() {
+        doReturn(Optional.empty()).when(toDoRepository).findById(anyInt());
+        ResourceNotFoundException e = assertThrows(ResourceNotFoundException.class, ()-> toDoService.deleteById(99));
+        assertThat(e.getMessage()).isEqualTo("タスク (id = 99) は存在しません");
+
+        verify(toDoRepository, times(1)).findById(anyInt());
+    }
 }

--- a/src/test/resources/datasets/expected_delete_to_do_list.yml
+++ b/src/test/resources/datasets/expected_delete_to_do_list.yml
@@ -1,0 +1,9 @@
+to_do_list:
+  - id: 1
+    is_done: 0
+    task: "テスト用タスク１"
+    limit_date: "2022-08-10"
+  - id: 2
+    is_done: 0
+    task: "テスト用タスク２"
+    limit_date: "2022-08-20"


### PR DESCRIPTION
## 概要（このPRの対応範囲）

* 新規CRUDアプリ（ToDoList）のDELETE部分を実装しました。
* DELETE機能のテストを実装しました。


## やったこと

- DELETE機能の実装 bf32583091d26655d28496866d04ae59bfc96882
	- [x] タスク削除機能（DELETE:/todos/{id})
- 例外処理の実装
	- [x] 存在しないタスクIDを削除しようとした時にNotFoundを返す
- テスト機能の実装
	- **ToDoRepositoryTest クラス** b728f5abdff6cd2564e62d4806a202d3cc474566
		- [x] タスクを削除できること
	- **ToDoServiceTest クラス** 81a9178175a661fb541ba6d663e50b885e21b98c
		- [x] タスクを削除できること
		- [x] 存在しないタスクを削除しようとしたときに正常に例外が投げられていること
	- **UserRestApiIntegrationTest クラス** 3011a6389673e44952fe63613af71f8837b6bed0
		- [x] タスクを削除できること
		- [x] 存在しないタスクIDを削除しようとした時にNotFoundが返ってくること